### PR TITLE
Convert network requests to asynchronous

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+    "esversion": 6,
+    "sub": true
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
     <meta charset="utf-8" />
     <title>WebGL PBR</title>
     <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: #222;
+        overflow: hidden;
+      }
+
       #error {
         background-color: red;
       }
@@ -75,7 +84,7 @@
     <script src="main.js"></script>
   </head>
 
-  <body style="margin:0; position:fixed; width:100%" onload="main()">
+  <body onload="main()">
     <div id="error"></div>
     <canvas id="canvas" width="600" height="600">
       Please use a browser that supports "canvas"

--- a/main.js
+++ b/main.js
@@ -200,11 +200,11 @@ function init(vertSource, fragSource) {
     if (!redrawQueued) {
       redrawQueued = true;
       window.requestAnimationFrame(function() {
+        redrawQueued = false;
         var scene = glState.scene;
         if (scene) {
           scene.drawScene(gl);
         }
-        redrawQueued = false;
       });
     }
   };

--- a/main.js
+++ b/main.js
@@ -71,15 +71,52 @@ function loadCubeMap(gl, envMap, type, state) {
 
 // Update model from dat.gui change
 function updateModel(value, gl, glState, viewMatrix, projectionMatrix, backBuffer, frontBuffer) {
-  scene = new Scene(gl, glState, "./models/" + value + "/glTF/", "./models/" + value + "/glTF/" + value + ".gltf");
-  scene.projectionMatrix = projectionMatrix;
-  scene.viewMatrix = viewMatrix;
-  scene.backBuffer = backBuffer;
-  scene.frontBuffer = frontBuffer;
-  return scene;
+  var error = document.getElementById('error');
+  glState.scene = null;
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+  $.ajax({
+    url: 'models/' + value + '/glTF/' + value + '.gltf',
+    dataType: 'json',
+    async: true,
+    error: (jqXhr, textStatus, errorThrown) => {
+      error.innerHTML += 'Failed to load model: ' + errorThrown + '<br>';
+    },
+    success: function(gltf) {
+      var scene = new Scene(gl, glState, "./models/" + value + "/glTF/", gltf);
+      scene.projectionMatrix = projectionMatrix;
+      scene.viewMatrix = viewMatrix;
+      scene.backBuffer = backBuffer;
+      scene.frontBuffer = frontBuffer;
+      glState.scene = scene;
+    }
+  });
 }
 
 function main() {
+  var error = document.getElementById('error');
+  var vertDeferred = $.ajax({
+    url: './shaders/pbr-vert.glsl',
+    dataType: 'text',
+    async: true,
+    error: (jqXhr, textStatus, errorThrown) => {
+      error.innerHTML += 'Failed to load the vertex shader: ' + errorThrown + '<br>';
+    }
+  });
+  var fragDeferred = $.ajax({
+    url: './shaders/pbr-frag.glsl',
+    dataType: 'text',
+    async: true,
+    error: (jqXhr, textStatus, errorThrown) => {
+      error.innerHTML += 'Failed to load the fragment shader: ' + errorThrown + '<br>';
+    }
+  });
+  $.when(vertDeferred, fragDeferred).then((vertSource, fragSource) => {
+    init(vertSource[0], fragSource[0]);
+  });
+}
+
+function init(vertSource, fragSource) {
   var canvas = document.getElementById('canvas');
   var canvas2d = document.getElementById('canvas2d');
   var error = document.getElementById('error');
@@ -105,12 +142,13 @@ function main() {
   gl.hasDerivativesExt = gl.getExtension('OES_standard_derivatives');
   gl.hasSRGBExt = gl.getExtension('EXT_SRGB');
 
-  // Initialize shaders
-  $.ajaxSetup({
-    async: false
-  });
-
-  glState = {"uniforms":{}, "attributes":{}};
+  glState = {
+    uniforms: {},
+    attributes: {},
+    vertSource: vertSource,
+    fragSource: fragSource,
+    scene: null
+  };
 
   // Create cube maps
   var envMap = "papermill";
@@ -149,9 +187,7 @@ function main() {
   glState.uniforms['u_scaleIBLAmbient'] = {'funcName':'uniform4f', vals:[1.0,1.0,1.0,1.0]};
 
   // Load scene
-  //var scene = new Scene(gl, "./models/DamagedHelmetModified/glTF/", "./models/DamagedHelmetModified/glTF/DamagedHelmetModified.gltf");
-  //var scene = new Scene(gl, "./models/MetalRoughSpheres/glTF/", "./models/MetalRoughSpheres/glTF/MetalRoughSpheres.gltf");
-  scene = updateModel("BoomBox", gl, glState, viewMatrix, projectionMatrix,canvas, ctx2d);
+  updateModel("BoomBox", gl, glState, viewMatrix, projectionMatrix, canvas, ctx2d);
 
   // Set clear color
   gl.clearColor(0.2, 0.2, 0.2, 1.0);
@@ -161,9 +197,12 @@ function main() {
 
   var redraw = function() {
     window.requestAnimationFrame(function() {
-      scene.drawScene(gl);
-    })
-  }
+      var scene = glState.scene;
+      if (scene) {
+        scene.drawScene(gl);
+      }
+    });
+  };
 
   // Set control callbacks
   canvas2d.onmousedown = function(ev) {handleMouseDown(ev);};
@@ -178,7 +217,7 @@ function main() {
   
   var text = {Model: "BoomBox"};
   folder.add(text, 'Model', ['MetalRoughSpheres', 'AppleTree', 'Avocado', 'BarramundiFish', 'BoomBox', 'Corset', 'FarmLandDiorama', 'Telephone', 'Triangle', 'WaterBottle']).onChange(function(value) {
-    scene = updateModel(value, gl, glState, viewMatrix, projectionMatrix, canvas, ctx2d);
+    updateModel(value, gl, glState, viewMatrix, projectionMatrix, canvas, ctx2d);
   });
   folder.open();
 

--- a/main.js
+++ b/main.js
@@ -195,13 +195,18 @@ function init(vertSource, fragSource) {
   // Enable depth test
   gl.enable(gl.DEPTH_TEST);
 
+  var redrawQueued = false;
   var redraw = function() {
-    window.requestAnimationFrame(function() {
-      var scene = glState.scene;
-      if (scene) {
-        scene.drawScene(gl);
-      }
-    });
+    if (!redrawQueued) {
+      redrawQueued = true;
+      window.requestAnimationFrame(function() {
+        var scene = glState.scene;
+        if (scene) {
+          scene.drawScene(gl);
+        }
+        redrawQueued = false;
+      });
+    }
   };
 
   // Set control callbacks

--- a/scene.js
+++ b/scene.js
@@ -7,7 +7,13 @@ class Mesh {
                     'USE_IBL':1,
                    }
 
-    this.glState  = {"uniforms":{}, "uniformLocations":{}, "attributes":{}};
+    this.glState  = {
+      uniforms: {},
+      uniformLocations: {},
+      attributes: {},
+      vertSource: globalState.vertSource,
+      fragSource: globalState.fragSource
+    };
 
     var primitives = gltf.meshes[meshIdx].primitives;
     // todo:  multiple primitives doesn't work.
@@ -66,9 +72,7 @@ class Mesh {
     }
   
     var vertexShader = gl.createShader(gl.VERTEX_SHADER);
-    $.get("./shaders/pbr-vert.glsl", function(response) {
-      gl.shaderSource(vertexShader, shaderDefines+response);
-    });
+    gl.shaderSource(vertexShader, shaderDefines + this.glState.vertSource);
     gl.compileShader(vertexShader);
     var compiled = gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS);
     if (!compiled) {
@@ -78,9 +82,7 @@ class Mesh {
     }
 
     var fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
-    $.get("./shaders/pbr-frag.glsl", function(response) {
-      gl.shaderSource(fragmentShader, shaderDefines+response);
-    });
+    gl.shaderSource(fragmentShader, shaderDefines + this.glState.fragSource);
     gl.compileShader(fragmentShader);
     compiled = gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS);
     if (!compiled) {
@@ -291,14 +293,7 @@ class Mesh {
 }
 
 class Scene {
-  constructor(gl, glState, model, file) {
-    // Load gltf file
-    var json;
-    $.get(file, function(response) {
-      json = response;
-    });
-    var gltf = (typeof json === 'string') ? JSON.parse(json) : json;
-
+  constructor(gl, glState, model, gltf) {
     this.globalState = glState;
 
     this.nodes = gltf.nodes;
@@ -456,11 +451,11 @@ function applyState(gl, program, globalState, localState) {
     }
   }
 
-  for(var uniform in globalState.uniforms) {
+  for(let uniform in globalState.uniforms) {
     applyUniform(globalState.uniforms[uniform], uniform);
   }
 
-  for(var uniform in localState.uniforms) {
+  for(let uniform in localState.uniforms) {
     applyUniform(localState.uniforms[uniform], uniform);
   }
 


### PR DESCRIPTION
This converts the jQuery XHR requests to async, avoiding a warning that was showing up in Chrome DevTools.

Also, I added a check to see if a `requestAnimationFrame` was already pending before scheduling a new one.  The problem is that `mouseMove` events can arrive by the dozens per animation frame, and scheduling a redraw for each one can be a substantial performance hit.  Mouse movements should be much more fluid as a result of this change.

Fixes moneimne/WebGL-PBR#4

/cc @snagy 